### PR TITLE
add in SampledDicts files for SamplingSource

### DIFF
--- a/larcoreobj/SummaryData/SampledDicts/CMakeLists.txt
+++ b/larcoreobj/SummaryData/SampledDicts/CMakeLists.txt
@@ -1,8 +1,4 @@
-cet_make(NO_DICTIONARY)
-
 art_dictionary(DICTIONARY_LIBRARIES larcoreobj_SummaryData)
-
-add_subdirectory(SampledDicts)
 
 install_headers()
 install_source()

--- a/larcoreobj/SummaryData/SampledDicts/classes.h
+++ b/larcoreobj/SummaryData/SampledDicts/classes.h
@@ -1,0 +1,5 @@
+#include "canvas/Persistency/Common/Sampled.h" 
+#include "canvas/Persistency/Common/Wrapper.h"
+
+#include "larcoreobj/SummaryData/RunData.h"
+#include "larcoreobj/SummaryData/POTSummary.h"

--- a/larcoreobj/SummaryData/SampledDicts/classes.h
+++ b/larcoreobj/SummaryData/SampledDicts/classes.h
@@ -1,4 +1,4 @@
-#include "canvas/Persistency/Common/Sampled.h" 
+#include "canvas/Persistency/Common/Sampled.h"
 #include "canvas/Persistency/Common/Wrapper.h"
 
 #include "larcoreobj/SummaryData/RunData.h"

--- a/larcoreobj/SummaryData/SampledDicts/classes_def.xml
+++ b/larcoreobj/SummaryData/SampledDicts/classes_def.xml
@@ -1,0 +1,13 @@
+<lcgdict>
+
+  <class name="std::map<art::SubRunID,sumdata::POTSummary>"/>
+  <class name="std::map<std::string,std::map<art::SubRunID,sumdata::POTSummary>>"/>
+  <class name="art::Sampled<sumdata::POTSummary>"/>
+  <class name="art::Wrapper<art::Sampled<sumdata::POTSummary>>"/>
+
+  <class name="std::map<art::SubRunID,sumdata::RunData>"/>
+  <class name="std::map<std::string,std::map<art::SubRunID,sumdata::RunData>>"/>
+  <class name="art::Sampled<sumdata::RunData>"/>
+  <class name="art::Wrapper<art::Sampled<sumdata::RunData>>"/>
+
+</lcgdict>


### PR DESCRIPTION
Add dictionary files for art::Sampled products, as suggested in https://cdcvs.fnal.gov/redmine/projects/art/wiki/SamplingInput_products

Should be non-breaking.