### PR TITLE
Migrate to Cetmodules 3.12.00 and modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 find_package(cetmodules REQUIRED)
 project(larcoreobj VERSION 09.05.01 LANGUAGES CXX)
 
-
 include(CetCMakeEnv)
 cet_cmake_env()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,10 @@ cet_set_compiler_flags(DIAGS CAUTIOUS
 
 cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)
 
-find_package(cetlib_except REQUIRED EXPORT)
-find_package(cetlib REQUIRED EXPORT)
+find_package(canvas_root_io REQUIRED EXPORT)
 find_package(canvas REQUIRED EXPORT)
-find_package(canvas_root_io REQUIRED)
+find_package(fhiclcpp REQUIRED EXPORT)
+find_package(ROOT COMPONENTS GenVector REQUIRED EXPORT)
 
 include(BuildDictionary)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,120 @@
+{
+   "configurePresets" : [
+      {
+         "cacheVariables" : {
+            "CMAKE_BUILD_TYPE" : {
+               "type" : "STRING",
+               "value" : "RelWithDebInfo"
+            },
+            "CMAKE_CXX_EXTENSIONS" : {
+               "type" : "BOOL",
+               "value" : "OFF"
+            },
+            "CMAKE_CXX_STANDARD_REQUIRED" : {
+               "type" : "BOOL",
+               "value" : "ON"
+            },
+            "larcoreobj_ADD_NOARCH_DIRS_INIT" : {
+               "type" : "INTERNAL",
+               "value" : "GDML_DIR;FHICL_DIR"
+            },
+            "larcoreobj_FHICL_DIR_INIT" : {
+               "type" : "STRING",
+               "value" : "job"
+            }
+         },
+         "description" : "Configuration settings translated from ups/product_deps",
+         "displayName" : "Configuration from product_deps",
+         "hidden" : true,
+         "name" : "from_product_deps"
+      },
+      {
+         "cacheVariables" : {
+            "CMAKE_CXX_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER}"
+            },
+            "CMAKE_CXX_STANDARD" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_STANDARD}"
+            },
+            "CMAKE_C_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER}"
+            },
+            "CMAKE_Fortran_COMPILER" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER}"
+            },
+            "UPS_CXX_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_ID}"
+            },
+            "UPS_CXX_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_CXX_COMPILER_VERSION}"
+            },
+            "UPS_C_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_ID}"
+            },
+            "UPS_C_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_C_COMPILER_VERSION}"
+            },
+            "UPS_Fortran_COMPILER_ID" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_ID}"
+            },
+            "UPS_Fortran_COMPILER_VERSION" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_Fortran_COMPILER_VERSION}"
+            },
+            "WANT_UPS" : {
+               "type" : "BOOL",
+               "value" : true
+            },
+            "larcoreobj_EXEC_PREFIX_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FQ_DIR}"
+            },
+            "larcoreobj_UPS_BUILD_ONLY_DEPENDENCIES_INIT" : {
+               "type" : "STRING",
+               "value" : "cetmodules"
+            },
+            "larcoreobj_UPS_PRODUCT_FLAVOR_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_FLAVOR}"
+            },
+            "larcoreobj_UPS_PRODUCT_NAME_INIT" : {
+               "type" : "STRING",
+               "value" : "larcoreobj"
+            },
+            "larcoreobj_UPS_QUALIFIER_STRING_INIT" : {
+               "type" : "STRING",
+               "value" : "$env{CETPKG_QUALSPEC}"
+            }
+         },
+         "description" : "Extra configuration for UPS package generation",
+         "displayName" : "UPS extra configuration",
+         "hidden" : true,
+         "name" : "extra_for_UPS"
+      },
+      {
+         "description" : "Default configuration including settings from ups/product_deps",
+         "displayName" : "Default configuration",
+         "inherits" : "from_product_deps",
+         "name" : "default"
+      },
+      {
+         "description" : "Default configuration for UPS package generation",
+         "displayName" : "Default configuration for UPS",
+         "inherits" : [
+            "default",
+            "extra_for_UPS"
+         ],
+         "name" : "for_UPS"
+      }
+   ],
+   "version" : 3
+}

--- a/larcoreobj/CMakeLists.txt
+++ b/larcoreobj/CMakeLists.txt
@@ -1,2 +1,4 @@
+cet_make_library(HEADERS_TARGET_ONLY)
+
 add_subdirectory(SummaryData)
 add_subdirectory(SimpleTypesAndConstants)

--- a/larcoreobj/SimpleTypesAndConstants/CMakeLists.txt
+++ b/larcoreobj/SimpleTypesAndConstants/CMakeLists.txt
@@ -1,7 +1,7 @@
+cet_make_library(SOURCE readout_types.h geo_types.cxx)
 
 find_package(ROOT COMPONENTS GenVector REQUIRED EXPORT)
 
-cet_make_library(HEADERS_TARGET SOURCE geo_types.cxx )
 cet_make_library(LIBRARY_NAME larcoreobj_geo_vectors INTERFACE SOURCE geo_vectors.h LIBRARIES INTERFACE ROOT::GenVector)
 build_dictionary(DICTIONARY_LIBRARIES larcoreobj_SimpleTypesAndConstants)
 

--- a/larcoreobj/SimpleTypesAndConstants/CMakeLists.txt
+++ b/larcoreobj/SimpleTypesAndConstants/CMakeLists.txt
@@ -2,7 +2,8 @@ cet_make_library(SOURCE readout_types.h geo_types.cxx)
 
 cet_make_library(LIBRARY_NAME geo_vectors INTERFACE
   SOURCE geo_vectors.h geo_optical_vectors.h
-  LIBRARIES INTERFACE ROOT::GenVector
+  LIBRARIES INTERFACE
+  ROOT::GenVector
 )
 
 cet_make_library(LIBRARY_NAME geo_types_fhicl INTERFACE
@@ -19,7 +20,9 @@ cet_make_library(LIBRARY_NAME readout_types_fhicl INTERFACE
   fhiclcpp::types
 )
 
-build_dictionary(DICTIONARY_LIBRARIES larcoreobj::geo_vectors)
+build_dictionary(DICTIONARY_LIBRARIES
+  larcoreobj::geo_vectors
+)
 
 install_headers()
 install_source()

--- a/larcoreobj/SimpleTypesAndConstants/CMakeLists.txt
+++ b/larcoreobj/SimpleTypesAndConstants/CMakeLists.txt
@@ -1,10 +1,25 @@
 cet_make_library(SOURCE readout_types.h geo_types.cxx)
 
-find_package(ROOT COMPONENTS GenVector REQUIRED EXPORT)
+cet_make_library(LIBRARY_NAME geo_vectors INTERFACE
+  SOURCE geo_vectors.h geo_optical_vectors.h
+  LIBRARIES INTERFACE ROOT::GenVector
+)
 
-cet_make_library(LIBRARY_NAME larcoreobj_geo_vectors INTERFACE SOURCE geo_vectors.h LIBRARIES INTERFACE ROOT::GenVector)
-build_dictionary(DICTIONARY_LIBRARIES larcoreobj_SimpleTypesAndConstants)
+cet_make_library(LIBRARY_NAME geo_types_fhicl INTERFACE
+  SOURCE geo_types_fhicl.h
+  LIBRARIES INTERFACE
+  larcoreobj::SimpleTypesAndConstants
+  fhiclcpp::types
+)
+
+cet_make_library(LIBRARY_NAME readout_types_fhicl INTERFACE
+  SOURCE readout_types_fhicl.h
+  LIBRARIES INTERFACE
+  larcoreobj::SimpleTypesAndConstants
+  fhiclcpp::types
+)
+
+build_dictionary(DICTIONARY_LIBRARIES larcoreobj::geo_vectors)
 
 install_headers()
 install_source()
-

--- a/larcoreobj/SummaryData/CMakeLists.txt
+++ b/larcoreobj/SummaryData/CMakeLists.txt
@@ -1,6 +1,6 @@
-cet_make_library( SOURCE GeometryConfigurationInfo.cxx  POTSummary.cxx  RunData.cxx )
+cet_make_library(SOURCE GeometryConfigurationInfo.cxx POTSummary.cxx RunData.cxx)
 
-build_dictionary(DICTIONARY_LIBRARIES larcoreobj_SummaryData canvas::canvas)
+build_dictionary(DICTIONARY_LIBRARIES larcoreobj::SummaryData canvas::canvas)
 
 add_subdirectory(SampledDicts)
 

--- a/larcoreobj/SummaryData/CMakeLists.txt
+++ b/larcoreobj/SummaryData/CMakeLists.txt
@@ -1,6 +1,9 @@
 cet_make_library(SOURCE GeometryConfigurationInfo.cxx POTSummary.cxx RunData.cxx)
 
-build_dictionary(DICTIONARY_LIBRARIES larcoreobj::SummaryData canvas::canvas)
+build_dictionary(DICTIONARY_LIBRARIES
+  larcoreobj::SummaryData
+  canvas::canvas
+)
 
 add_subdirectory(SampledDicts)
 

--- a/larcoreobj/SummaryData/SampledDicts/CMakeLists.txt
+++ b/larcoreobj/SummaryData/SampledDicts/CMakeLists.txt
@@ -1,4 +1,7 @@
-build_dictionary(DICTIONARY_LIBRARIES larcoreobj_SummaryData canvas::canvas)
+build_dictionary(DICTIONARY_LIBRARIES
+  larcoreobj_SummaryData
+  canvas::canvas
+)
 
 install_headers()
 install_source()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,2 @@
-
 include(CetTest)
 add_subdirectory(SimpleTypesAndConstants)

--- a/test/SimpleTypesAndConstants/CMakeLists.txt
+++ b/test/SimpleTypesAndConstants/CMakeLists.txt
@@ -3,19 +3,24 @@
 # Testing
 #
 # ======================================================================
+find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
-find_package(Boost REQUIRED)
+cet_test(geo_types_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE larcoreobj::SimpleTypesAndConstants)
 
-cet_test( geo_types_test USE_BOOST_UNIT )
-cet_test( readout_types_test USE_BOOST_UNIT )
-cet_test( geo_types_fhicl_test USE_BOOST_UNIT
+cet_test(readout_types_test USE_BOOST_UNIT
+  LIBRARIES PRIVATE larcoreobj::SimpleTypesAndConstants)
+
+cet_test(geo_types_fhicl_test USE_BOOST_UNIT
   LIBRARIES PRIVATE
-    fhiclcpp::fhiclcpp fhiclcpp::types
-    cetlib_except::cetlib_except
-  )
-cet_test( readout_types_fhicl_test USE_BOOST_UNIT
+  larcoreobj::geo_types_fhicl
+  fhiclcpp::types
+  fhiclcpp::fhiclcpp
+)
+cet_test(readout_types_fhicl_test USE_BOOST_UNIT
   LIBRARIES PRIVATE
-    fhiclcpp::fhiclcpp fhiclcpp::types
-    cetlib_except::cetlib_except
-  )
-cet_test( testPhysicalConstants )
+  larcoreobj::readout_types_fhicl
+  fhiclcpp::types
+  fhiclcpp::fhiclcpp
+)
+cet_test(testPhysicalConstants)

--- a/test/SimpleTypesAndConstants/CMakeLists.txt
+++ b/test/SimpleTypesAndConstants/CMakeLists.txt
@@ -6,10 +6,14 @@
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 cet_test(geo_types_test USE_BOOST_UNIT
-  LIBRARIES PRIVATE larcoreobj::SimpleTypesAndConstants)
+  LIBRARIES PRIVATE
+  larcoreobj::SimpleTypesAndConstants
+)
 
 cet_test(readout_types_test USE_BOOST_UNIT
-  LIBRARIES PRIVATE larcoreobj::SimpleTypesAndConstants)
+  LIBRARIES PRIVATE
+  larcoreobj::SimpleTypesAndConstants
+)
 
 cet_test(geo_types_fhicl_test USE_BOOST_UNIT
   LIBRARIES PRIVATE

--- a/test/SimpleTypesAndConstants/geo_types_fhicl_test.cc
+++ b/test/SimpleTypesAndConstants/geo_types_fhicl_test.cc
@@ -19,9 +19,10 @@
 
 
 // C/C++ standard libraries
-#include <iostream>
-#include <string>
 #include <array>
+#include <iostream>
+#include <stdexcept>
+#include <string>
 #include <type_traits> // std::is_same_v<>
 
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -249,7 +249,7 @@ gdmldir	product_dir
 ####################################
 product		version		qual	flags		<table_format=2>
 canvas_root_io	v1_09_04	-
-cetmodules	v3_09_03	-	only_for_build
+cetmodules	v3_12_00	-	only_for_build
 end_product_list
 ####################################
 


### PR DESCRIPTION
- Cetmodules -> 3.12.00
- Correct std C++ includes
- Generate headers target separately to avoid confusion
- Improve CMake use and tighten dependencies
- Minor formatting for readability and scripted dependency checking
- Presets generated by Cetmodules 3.12.00
