### PR TITLE
Adjustments to support Spack development

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,14 +13,6 @@
             "CMAKE_CXX_STANDARD_REQUIRED" : {
                "type" : "BOOL",
                "value" : "ON"
-            },
-            "larcoreobj_ADD_NOARCH_DIRS_INIT" : {
-               "type" : "INTERNAL",
-               "value" : "GDML_DIR;FHICL_DIR"
-            },
-            "larcoreobj_FHICL_DIR_INIT" : {
-               "type" : "STRING",
-               "value" : "job"
             }
          },
          "description" : "Configuration settings translated from ups/product_deps",

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -173,9 +173,6 @@ defaultqual	e26
 #     Wirecell data.
 #
 ####################################
-fcldir	product_dir	job
-gdmldir	product_dir
-####################################
 
 ####################################
 # Product table.


### PR DESCRIPTION
Removes unnecessary specifications in `ups/product_deps` and `CMakePresets.json`.