### PR TITLE
Remove unneeded `const` in return type

### DIFF
--- a/larcoreobj/SimpleTypesAndConstants/geo_types.h
+++ b/larcoreobj/SimpleTypesAndConstants/geo_types.h
@@ -45,7 +45,7 @@ namespace geo::details {
   }
 
   template <typename T>
-  constexpr auto const index_for()
+  constexpr auto index_for()
   {
     std::size_t index{};
     index_impl<T>(index);


### PR DESCRIPTION
Resolves Clang 14 warning:

```
[2160/2314] Building CXX object larrecodnn/larrecodnn/HDF5Maker/Tables/CMakeFiles/larrecodnn_HDF5Maker_Tables.dir/LDepTable.cxx.o
FAILED: larrecodnn/larrecodnn/HDF5Maker/Tables/CMakeFiles/larrecodnn_HDF5Maker_Tables.dir/LDepTable.cxx.o
/cvmfs/larsoft.opensciencegrid.org/products/clang/v14_0_6c/Linux64bit+3.10-2.17/bin/clang++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DH5_BUILT_AS_DYNAMIC_LIB -DNDEBUG -DTBB_USE_DEBUG -D_FILE_OFFSET_BITS=
64 -D_GNU_SOURCE -D_LARGEFILE64_SOURCE -D_LARGEFILE_SOURCE -D_POSIX_C_SOURCE=200809L -Dlarrecodnn_HDF5Maker_Tables_EXPORTS -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcoreobj -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larcoreobj
-I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcorealg -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larcorealg -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/lardataobj -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x
86_64/lardataobj -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcore -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larcore -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/lardataalg -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/b
uild_slf7.x86_64/lardataalg -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larvecutils -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larvecutils -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/lardata -I/scratch/knoepfel/sl7-work/larsoft-
devel/c14_prof/build_slf7.x86_64/lardata -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larevt -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larevt -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larg4 -I/scratch/knoepfel/sl7-work/larsoft
-devel/c14_prof/build_slf7.x86_64/larg4 -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larsim -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larsim -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larfinder -I/scratch/knoepfel/sl7-work/lars
oft-devel/c14_prof/build_slf7.x86_64/larfinder -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larreco -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larreco -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larpandora -I/scratch/knoepfel/sl7
-work/larsoft-devel/c14_prof/build_slf7.x86_64/larpandora -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larana -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larana -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larwirecell -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larwirecell -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larsimrad -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larsimrad -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larsimdn
n -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larsimdnn -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larsoftobj -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larsoftobj -I/scratch/knoepfel/sl7-work/larsoft-deve
l/srcs/larexamples -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larexamples -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larrecodnn -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larrecodnn -I/scratch/knoepfel/sl
7-work/larsoft-devel/srcs/lareventdisplay -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/lareventdisplay -I/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larsoft -I/scratch/knoepfel/sl7-work/larsoft-devel/c14_prof/build_slf7.x86_64/larsoft -
I/cvmfs/larsoft.opensciencegrid.org/products/hep_hpc/v0_15_00/Linux64bit+3.10-2.17-c14-prof/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/art/v3_14_04/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/canvas/v3_16_04/include -isystem /cv
mfs/larsoft.opensciencegrid.org/products/fhiclcpp/v4_18_04/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/cetlib/v3_18_02/slf7.x86_64.c14.prof/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/boost/v1_82_0/Linux64bit+3.10-2.17-c14-prof/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/cetlib_except/v1_09_01/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/hep_concurrency/v1_09_02/slf7.x86_64.c14.prof/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/tbb/v2021_9_0/Linux64bit+3.10-2.17-c14/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/nusimdata/v1_29_03/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/root/v6_28_12/Linux64bit+3.10-2.17-c14-p3915-prof/include -isystem /cvmfs/larsoft.opensciencegr
id.org/products/nug4/v1_17_03/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/messagefacility/v2_10_05/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/range/v3_0_12_0/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/clhep/v2_
4_7_1/Linux64bit+3.10-2.17-c14-prof/include -isystem /cvmfs/larsoft.opensciencegrid.org/products/hdf5/v1_12_2b/Linux64bit+3.10-2.17-c14-prof/include -g -O3 -fno-omit-frame-pointer -DNDEBUG -std=c++17 -fPIC -Werror -grecord-gcc-switches -Wall -Werror=return-type -
Wno-unused-local-typedefs -gdwarf-4 -Wextra -Wno-long-long -Winit-self -Wdelete-non-virtual-dtor -Woverloaded-virtual -Wnon-virtual-dtor -pedantic -pthread -MD -MT larrecodnn/larrecodnn/HDF5Maker/Tables/CMakeFiles/larrecodnn_HDF5Maker_Tables.dir/LDepTable.cxx.o -
MF larrecodnn/larrecodnn/HDF5Maker/Tables/CMakeFiles/larrecodnn_HDF5Maker_Tables.dir/LDepTable.cxx.o.d -o larrecodnn/larrecodnn/HDF5Maker/Tables/CMakeFiles/larrecodnn_HDF5Maker_Tables.dir/LDepTable.cxx.o -c /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larrecodnn
/larrecodnn/HDF5Maker/Tables/LDepTable.cxx
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larrecodnn/larrecodnn/HDF5Maker/Tables/LDepTable.cxx:4:
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larsim/larsim/MCCheater/PhotonBackTrackerService.h:14:
/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcoreobj/larcoreobj/SimpleTypesAndConstants/geo_types.h:48:18: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
  constexpr auto const index_for()
```